### PR TITLE
Adds file links to emails

### DIFF
--- a/admin/views/Forms/response.php
+++ b/admin/views/Forms/response.php
@@ -28,7 +28,19 @@
                             <?php
 
                             if (is_array($oAnswer->answer)) {
+
                                 echo implode('<br />', $oAnswer->answer);
+
+                            } elseif (!empty($oAnswer->field->type)) {
+
+                                $sClass = $oAnswer->field->type;
+                                $oField = new $sClass();
+
+                                echo $oField->extractText(
+                                    $oAnswer->answer,
+                                    $oAnswer->answer
+                                );
+
                             } else {
                                 echo $oAnswer->answer;
                             }

--- a/forms/controllers/Forms.php
+++ b/forms/controllers/Forms.php
@@ -88,7 +88,10 @@ class Forms extends Base
                             $mAnswer = !empty($_POST['field'][$oField->id]) ? $_POST['field'][$oField->id] : null;
 
                             $aData['answers'][$oField->id] = [
-                                'field_id' => $oField->id,
+                                'field'    => (object) [
+                                    'id'   => $oField->id,
+                                    'type' => get_class($oFieldType),
+                                ],
                                 'question' => $oField->label,
                                 'answer'   => null,
                             ];
@@ -237,7 +240,7 @@ class Forms extends Base
                 $sAnswerToTest = $oAnswer->answer;
             }
 
-            if ($oAnswer->field_id == $oNotify->condition_field_id) {
+            if ($oAnswer->field->id == $oNotify->condition_field_id) {
                 switch ($oNotify->condition_operator) {
                     case $oModel::OPERATOR_IS:
                         return strtolower($sAnswerToTest) == strtolower($oNotify->condition_value);

--- a/forms/views/email/form_submitted.php
+++ b/forms/views/email/form_submitted.php
@@ -4,35 +4,44 @@
 <hr />
 <table class="default-style">
     <tbody>
-    <?php
+        <?php
 
-    foreach ($emailObject->data->answers as $oAnswer) {
+        foreach ($emailObject->data->answers as $oAnswer) {
 
-        ?>
-        <tr>
-            <td class="left-header-cell">
-                <?=$oAnswer->question?>
-            </td>
-            <td>
-                <?php
+            ?>
+            <tr>
+                <td class="left-header-cell">
+                    <?=$oAnswer->question?>
+                </td>
+                <td>
+                    <?php
 
-                if (is_array($oAnswer->answer)) {
+                    if (is_array($oAnswer->answer)) {
 
-                    foreach ($oAnswer->answer as $sAnswer) {
-                        echo $sAnswer;
+                        foreach ($oAnswer->answer as $sAnswer) {
+                            echo $sAnswer;
+                        }
+
+                    } elseif (!empty($oAnswer->field->type)) {
+
+                        $sClass = $oAnswer->field->type;
+                        $oField = new $sClass();
+
+                        echo $oField->extractText(
+                            $oAnswer->answer,
+                            $oAnswer->answer
+                        );
+
+                    } else {
+                        echo $oAnswer->answer;
                     }
 
-                } else {
+                    ?>
+                </td>
+            </tr>
+            <?php
+        }
 
-                    echo $oAnswer->answer;
-                }
-
-                ?>
-            </td>
-        </tr>
-        <?php
-    }
-
-    ?>
+        ?>
     </tbody>
 </table>

--- a/forms/views/email/form_submitted_plaintext.php
+++ b/forms/views/email/form_submitted_plaintext.php
@@ -13,6 +13,17 @@ foreach ($emailObject->data->answers as $oAnswer) {
             echo strip_tags($sAnswer) . "\n\n";
         }
 
+    } elseif (!empty($oAnswer->field->type)) {
+
+        $sClass = $oAnswer->field->type;
+        $oField = new $sClass();
+
+        echo $oField->extractText(
+                $oAnswer->answer,
+                $oAnswer->answer,
+                true
+            ) . "\n\n";
+
     } else {
 
         echo strip_tags($oAnswer->answer) . "\n\n";


### PR DESCRIPTION
Previously, when a field was of type `File`, the value shown in the email was simple the object's ID. This PR renders it as a download link/button in both the notification emails and the admin interface.

<img width="822" alt="Screenshot 2019-10-11 00 03 09" src="https://user-images.githubusercontent.com/233585/66612744-cac71580-ebba-11e9-927f-f16a6b9955a3.png">

<img width="1792" alt="Screenshot 2019-10-11 00 05 08" src="https://user-images.githubusercontent.com/233585/66612746-cd296f80-ebba-11e9-9e86-529d5b9bd311.png">
